### PR TITLE
feat(drag-drop): implement drag and drop in Kanban and List views with task status updates

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "dayly",
       "version": "0.0.0",
       "dependencies": {
+        "@dnd-kit/core": "^6.3.1",
         "@radix-ui/react-checkbox": "^1.3.2",
         "@radix-ui/react-dialog": "^1.1.14",
         "@radix-ui/react-label": "^2.1.7",
@@ -558,6 +559,45 @@
       "license": "MIT",
       "dependencies": {
         "ms": "^2.1.1"
+      }
+    },
+    "node_modules/@dnd-kit/accessibility": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/accessibility/-/accessibility-3.1.1.tgz",
+      "integrity": "sha512-2P+YgaXF+gRsIihwwY1gCsQSYnu9Zyj2py8kY5fFvUM1qm2WA2u639R6YNVfU4GWr+ZM5mqEsfHZZLoRONbemw==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/core": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/core/-/core-6.3.1.tgz",
+      "integrity": "sha512-xkGBRQQab4RLwgXxoqETICr6S5JlogafbhNsidmrkVv2YRs5MLwpjoF2qpiGjQt8S9AoxtIV603s0GIUpY5eYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@dnd-kit/accessibility": "^3.1.1",
+        "@dnd-kit/utilities": "^3.2.2",
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/utilities": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/utilities/-/utilities-3.2.2.tgz",
+      "integrity": "sha512-+MKAJEOfaBe5SmV6t34p80MMKhjvUz0vRrvVJbPT0WElzaOJ/1xs+D+KDv+tD/NE5ujfrChEcshd4fLn0wpiqg==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.0.0",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",
+        "@dnd-kit/sortable": "^10.0.0",
         "@radix-ui/react-checkbox": "^1.3.2",
         "@radix-ui/react-dialog": "^1.1.14",
         "@radix-ui/react-label": "^2.1.7",
@@ -586,6 +587,20 @@
       "peerDependencies": {
         "react": ">=16.8.0",
         "react-dom": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/sortable": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/sortable/-/sortable-10.0.0.tgz",
+      "integrity": "sha512-+xqhmIIzvAYMGfBYYnbKuNicfSsk4RksY2XdmJhT+HAC01nix6fHCztU68jooFiMUB01Ky3F0FyOvhG/BZrWkg==",
+      "license": "MIT",
+      "dependencies": {
+        "@dnd-kit/utilities": "^3.2.2",
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "@dnd-kit/core": "^6.3.0",
+        "react": ">=16.8.0"
       }
     },
     "node_modules/@dnd-kit/utilities": {

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "cypress": "cypress open"
   },
   "dependencies": {
+    "@dnd-kit/core": "^6.3.1",
     "@radix-ui/react-checkbox": "^1.3.2",
     "@radix-ui/react-dialog": "^1.1.14",
     "@radix-ui/react-label": "^2.1.7",

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   },
   "dependencies": {
     "@dnd-kit/core": "^6.3.1",
+    "@dnd-kit/sortable": "^10.0.0",
     "@radix-ui/react-checkbox": "^1.3.2",
     "@radix-ui/react-dialog": "^1.1.14",
     "@radix-ui/react-label": "^2.1.7",

--- a/src/components/KanbanBoard/KanbanBoard.tsx
+++ b/src/components/KanbanBoard/KanbanBoard.tsx
@@ -1,3 +1,4 @@
+import { DndContext, closestCenter } from "@dnd-kit/core";
 import { TaskColumn } from "../TaskColumn.tsx/TaskColumn";
 import type { Task } from "@/store/useTaskStore";
 
@@ -11,14 +12,16 @@ export function KanbanBoard({ tasks }: { tasks: Task[] }) {
 
   return (
     <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-4">
-      {columns.map(({ title, status }) => (
-        <TaskColumn
-          key={status}
-          title={title}
-          status={status}
-          tasks={tasks.filter((t) => t.status === status)}
-        />
-      ))}
+      <DndContext collisionDetection={closestCenter}>
+        {columns.map(({ title, status }) => (
+          <TaskColumn
+            key={status}
+            title={title}
+            status={status}
+            tasks={tasks.filter((t) => t.status === status)}
+          />
+        ))}
+      </DndContext>
     </div>
   );
 }

--- a/src/components/KanbanBoard/KanbanBoard.tsx
+++ b/src/components/KanbanBoard/KanbanBoard.tsx
@@ -17,18 +17,45 @@ export function KanbanBoard({ tasks: tasksProp }: { tasks?: Task[] }) {
       { title: "Terminées", status: "done" },
     ];
 
-  const handleDragEnd = (event: DragEndEvent) => {
-    const { active, over } = event;
+const handleDragEnd = (event: DragEndEvent) => {
+  const { active, over } = event;
+  if (!over || active.id === over.id) return;
 
-    if (!over || active.id === over.id) return;
+  const taskId = String(active.id);
+  const overId = String(over.id);
 
-    const taskId = String(active.id);
-    const newStatusRaw = over.id;
-      if (!isTaskStatus(newStatusRaw)) return;
-    const newStatus: TaskStatus = newStatusRaw;
-    
-    updateTask(taskId, { status: newStatus });
-  };
+  // Trouver la tâche déplacée
+  const movedTask = tasks.find((t) => t.id === taskId);
+  if (!movedTask) return;
+
+  // Si on droppe sur une colonne (pas sur une carte)
+  const isColumnDrop = ["todo", "in-progress", "done"].includes(overId);
+
+  // Filtrer les tâches de la colonne cible
+  const targetStatus = isColumnDrop ? overId : tasks.find((t) => t.id === overId)?.status;
+  if (!isTaskStatus(targetStatus)) return;
+
+  // Liste des tâches dans la colonne cible, triées par order
+  const columnTasks = tasks
+    .filter((t) => t.status === targetStatus && t.id !== taskId)
+    .sort((a, b) => (a.order ?? 0) - (b.order ?? 0));
+
+  let newOrder = 0;
+  if (isColumnDrop) {
+    // Drop en bas de colonne
+    newOrder = columnTasks.length > 0 ? (columnTasks[columnTasks.length - 1].order ?? columnTasks.length - 1) + 1 : 0;
+  } else {
+    // Drop sur une carte : placer avant la carte cible
+    const overIndex = columnTasks.findIndex((t) => t.id === overId);
+    newOrder = overIndex === -1 ? 0 : columnTasks[overIndex].order ?? overIndex;
+    // Décale les autres tâches si besoin
+    columnTasks
+      .filter((t) => (t.order ?? 0) >= newOrder)
+      .forEach((t) => updateTask(t.id, { order: (t.order ?? 0) + 1 }));
+  }
+
+  updateTask(taskId, { status: targetStatus, order: newOrder });
+};
 
   return (
     <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-4">
@@ -38,7 +65,9 @@ export function KanbanBoard({ tasks: tasksProp }: { tasks?: Task[] }) {
             key={status}
             title={title}
             status={status}
-            tasks={tasks.filter((t) => t.status === status)}
+            tasks={tasks
+              .filter((t) => t.status === status)
+              .sort((a, b) => (a.order ?? 0) - (b.order ?? 0))}
           />
         ))}
       </DndContext>

--- a/src/components/KanbanBoard/KanbanBoard.tsx
+++ b/src/components/KanbanBoard/KanbanBoard.tsx
@@ -1,8 +1,15 @@
-import { DndContext, closestCenter } from "@dnd-kit/core";
+import { DndContext, closestCenter, type DragEndEvent } from "@dnd-kit/core";
 import { TaskColumn } from "../TaskColumn.tsx/TaskColumn";
-import type { Task } from "@/store/useTaskStore";
+import { useTaskStore } from "@/store/useTaskStore";
+import type { Task, TaskStatus } from "@/store/useTaskStore";
 
-export function KanbanBoard({ tasks }: { tasks: Task[] }) {
+const isTaskStatus = (value: any): value is TaskStatus => {
+return ["todo", "in-progress", "done"].includes(value);
+};
+export function KanbanBoard({ tasks: tasksProp }: { tasks?: Task[] }) {
+  const { tasks: storeTasks, updateTask } = useTaskStore();
+  const tasks = tasksProp ?? storeTasks;
+  
   const columns: { title: string; status: "todo" | "in-progress" | "done" }[] =
     [
       { title: "À faire", status: "todo" },
@@ -10,9 +17,22 @@ export function KanbanBoard({ tasks }: { tasks: Task[] }) {
       { title: "Terminées", status: "done" },
     ];
 
+  const handleDragEnd = (event: DragEndEvent) => {
+    const { active, over } = event;
+
+    if (!over || active.id === over.id) return;
+
+    const taskId = String(active.id);
+    const newStatusRaw = over.id;
+      if (!isTaskStatus(newStatusRaw)) return;
+    const newStatus: TaskStatus = newStatusRaw;
+    
+    updateTask(taskId, { status: newStatus });
+  };
+
   return (
     <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-4">
-      <DndContext collisionDetection={closestCenter}>
+      <DndContext collisionDetection={closestCenter} onDragEnd={handleDragEnd}>
         {columns.map(({ title, status }) => (
           <TaskColumn
             key={status}

--- a/src/components/KanbanBoard/KanbanBoard.tsx
+++ b/src/components/KanbanBoard/KanbanBoard.tsx
@@ -3,8 +3,8 @@ import { TaskColumn } from "../TaskColumn.tsx/TaskColumn";
 import { useTaskStore } from "@/store/useTaskStore";
 import type { Task, TaskStatus } from "@/store/useTaskStore";
 
-const isTaskStatus = (value: any): value is TaskStatus => {
-return ["todo", "in-progress", "done"].includes(value);
+const isTaskStatus = (value: unknown): value is TaskStatus => {
+return typeof value === "string" && ["todo", "in-progress", "done"].includes(value);
 };
 export function KanbanBoard({ tasks: tasksProp }: { tasks?: Task[] }) {
   const { tasks: storeTasks, updateTask } = useTaskStore();
@@ -49,9 +49,10 @@ const handleDragEnd = (event: DragEndEvent) => {
     const overIndex = columnTasks.findIndex((t) => t.id === overId);
     newOrder = overIndex === -1 ? 0 : columnTasks[overIndex].order ?? overIndex;
     // Décale les autres tâches si besoin
-    columnTasks
+    const updates = columnTasks
       .filter((t) => (t.order ?? 0) >= newOrder)
-      .forEach((t) => updateTask(t.id, { order: (t.order ?? 0) + 1 }));
+      .map((t) => ({ id: t.id, changes: { order: (t.order ?? 0) + 1 } }));
+    updates.forEach(({ id, changes }) => updateTask(id, changes));
   }
 
   updateTask(taskId, { status: targetStatus, order: newOrder });

--- a/src/components/ListView/ListView.tsx
+++ b/src/components/ListView/ListView.tsx
@@ -1,40 +1,109 @@
 import { DndContext, closestCenter } from "@dnd-kit/core";
-import type { Task } from "@/store/useTaskStore";
+import { SortableContext, useSortable, arrayMove, verticalListSortingStrategy } from "@dnd-kit/sortable";
+import { CSS } from "@dnd-kit/utilities";
+import { GripVertical, Pencil, Trash } from "lucide-react";
+import { useTaskStore, type Task } from "@/store/useTaskStore";
+import { toast } from "sonner";
 import { cn } from "@/lib/utils";
 
+// Composant pour afficher une tâche sortable
+function SortableTask({ task }: { task: Task }) {
+  const { removeTask } = useTaskStore();
+  const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({ id: task.id });
+  return (
+    <div
+      ref={setNodeRef}
+      style={{
+        transform: CSS.Transform.toString(transform),
+        transition,
+        opacity: isDragging ? 0.5 : 1,
+        cursor: "default",
+      }}
+      className={cn(
+        "border rounded-lg p-4 flex justify-between items-center gap-2",
+        task.completed ? "bg-muted" : "bg-white"
+      )}
+    >
+      {/* Drag handle */}
+      <span
+        {...listeners}
+        {...attributes}
+        className="mr-2 cursor-grab text-gray-400 hover:text-gray-600"
+        tabIndex={0}
+        aria-label="Déplacer"
+      >
+        <GripVertical size={20} />
+      </span>
+      <div className="flex-1 min-w-0">
+        <h3 className="font-semibold truncate">{task.title}</h3>
+        <p className="text-sm text-muted-foreground truncate">
+          Échéance : {task.dueDate} | Priorité : {task.priority}
+        </p>
+      </div>
+      <span
+        className={cn(
+          "text-xs font-medium px-2 py-1 rounded",
+          task.status === "todo" && "bg-gray-200",
+          task.status === "in-progress" && "bg-yellow-200",
+          task.status === "done" && "bg-green-200"
+        )}
+      >
+        {task.status}
+      </span>
+      {/* Bouton modifier */}
+      <button
+        className="ml-2 p-1 rounded hover:bg-gray-100"
+        title="Modifier"
+        // onClick={() => ...}
+      >
+        <Pencil size={18} />
+      </button>
+      {/* Bouton supprimer */}
+      <button
+        className="ml-1 p-1 rounded hover:bg-red-100 text-red-500"
+        title="Supprimer"
+        onClick={() => {
+          removeTask(task.id);
+          toast.success("Tâche supprimée avec succès")
+        }}
+        aria-label={`Supprimer la tâche ${task.title}`}
+      >
+        <Trash size={18} />
+      </button>
+    </div>
+  );
+}
+
 export function ListView({ tasks }: { tasks: Task[] }) {
+  const setTasks = useTaskStore((s) => s.setTasks);
+    // Trie les tâches par ordre
+  const sortedTasks = tasks.slice().sort((a, b) => (a.order ?? 0) - (b.order ?? 0));
+
+  function handleDragEnd(event: any) {
+    const { active, over } = event;
+    if (!over || active.id === over.id) return;
+
+    const oldIndex = sortedTasks.findIndex((t) => t.id === active.id);
+    const newIndex = sortedTasks.findIndex((t) => t.id === over.id);
+    const newTasks = arrayMove(sortedTasks, oldIndex, newIndex)
+      .map((task, idx) => ({ ...task, order: idx + 1 }));
+    setTasks(newTasks);
+  }
+
   return (
     <div className="space-y-2">
       {tasks.length === 0 && (
         <p className="text-muted-foreground">Aucune tâche à afficher.</p>
       )}
-      <DndContext collisionDetection={closestCenter}>
-        {tasks.map((task) => (
-          <div
-            key={task.id}
-            className={cn(
-              "border rounded-lg p-4 flex justify-between items-center",
-              task.completed ? "bg-muted" : "bg-white"
-            )}
-          >
-            <div>
-              <h3 className="font-semibold">{task.title}</h3>
-              <p className="text-sm text-muted-foreground">
-                Échéance : {task.dueDate} | Priorité : {task.priority}
-              </p>
-            </div>
-            <span
-              className={cn(
-                "text-xs font-medium px-2 py-1 rounded",
-                task.status === "todo" && "bg-gray-200",
-                task.status === "in-progress" && "bg-yellow-200",
-                task.status === "done" && "bg-green-200"
-              )}
-            >
-              {task.status}
-            </span>
-          </div>
-        ))}
+      <DndContext collisionDetection={closestCenter} onDragEnd={handleDragEnd}>
+        <SortableContext
+          items={sortedTasks.map((t) => t.id)}
+          strategy={verticalListSortingStrategy}
+        >
+          {sortedTasks.map((task) => (
+            <SortableTask key={task.id} task={task} />
+          ))}
+        </SortableContext>
       </DndContext>
     </div>
   );

--- a/src/components/ListView/ListView.tsx
+++ b/src/components/ListView/ListView.tsx
@@ -1,3 +1,4 @@
+import { DndContext, closestCenter } from "@dnd-kit/core";
 import type { Task } from "@/store/useTaskStore";
 import { cn } from "@/lib/utils";
 
@@ -7,33 +8,34 @@ export function ListView({ tasks }: { tasks: Task[] }) {
       {tasks.length === 0 && (
         <p className="text-muted-foreground">Aucune tâche à afficher.</p>
       )}
-
-      {tasks.map((task) => (
-        <div
-          key={task.id}
-          className={cn(
-            "border rounded-lg p-4 flex justify-between items-center",
-            task.completed ? "bg-muted" : "bg-white"
-          )}
-        >
-          <div>
-            <h3 className="font-semibold">{task.title}</h3>
-            <p className="text-sm text-muted-foreground">
-              Échéance : {task.dueDate} | Priorité : {task.priority}
-            </p>
-          </div>
-          <span
+      <DndContext collisionDetection={closestCenter}>
+        {tasks.map((task) => (
+          <div
+            key={task.id}
             className={cn(
-              "text-xs font-medium px-2 py-1 rounded",
-              task.status === "todo" && "bg-gray-200",
-              task.status === "in-progress" && "bg-yellow-200",
-              task.status === "done" && "bg-green-200"
+              "border rounded-lg p-4 flex justify-between items-center",
+              task.completed ? "bg-muted" : "bg-white"
             )}
           >
-            {task.status}
-          </span>
-        </div>
-      ))}
+            <div>
+              <h3 className="font-semibold">{task.title}</h3>
+              <p className="text-sm text-muted-foreground">
+                Échéance : {task.dueDate} | Priorité : {task.priority}
+              </p>
+            </div>
+            <span
+              className={cn(
+                "text-xs font-medium px-2 py-1 rounded",
+                task.status === "todo" && "bg-gray-200",
+                task.status === "in-progress" && "bg-yellow-200",
+                task.status === "done" && "bg-green-200"
+              )}
+            >
+              {task.status}
+            </span>
+          </div>
+        ))}
+      </DndContext>
     </div>
   );
 }

--- a/src/components/TaskCard/TaskCard.tsx
+++ b/src/components/TaskCard/TaskCard.tsx
@@ -5,7 +5,7 @@ import { toast } from "sonner";
 import { useTaskStore } from "@/store/useTaskStore";
 import { Card, CardContent } from "@/components/ui/card";
 import { Checkbox } from "@/components/ui/checkbox";
-import { CalendarDays } from "lucide-react";
+import { CalendarDays, GripVertical } from "lucide-react";
 
 export type Task = {
   id: string;
@@ -53,14 +53,24 @@ export default function TaskCard({ task }: TaskCardProps) {
     <div
     ref={setNodeRef}
       {...attributes}
-      {...listeners}
+      
       style={style}
       className={`transition-opacity ${
         isDragging ? "opacity-50" : ""
       }`}>
       <Card className="mb-2">
         <CardContent className="flex flex-col sm:flex-row justify-between items-start sm:items-center gap-3 p-4">
-          <div className="flex items-center gap-3">
+          <div className="flex flex-1 items-center gap-3 cursor-grab">
+            {/* Drag handle */}
+            <span
+              {...listeners}
+              className="cursor-grab active:cursor-grabbing select-none"
+              title="Déplacer"
+              aria-label="Déplacer la tâche"
+            >
+              {/* Utilise une icône si tu veux */}
+              <GripVertical />
+            </span>
             <Checkbox
               id={`checkbox-${task.id}`}
               checked={task.completed}
@@ -105,17 +115,21 @@ export default function TaskCard({ task }: TaskCardProps) {
             )}
             {/* Bouton Modifier */}
             <button
-              onClick={() => setEditOpen(true)}
+              onClick={(e) => {
+    e.stopPropagation();
+    setEditOpen(true);
+  }}
               className="text-xs text-blue-500 hover:underline"
             >
               Modifier
             </button>
             {/* Bouton Supprimer */}
             <button
-              onClick={() => {
-                removeTask(task.id);
-                toast.success("Tâche supprimée avec succès");
-              }}
+              onClick={(e) => {
+    e.stopPropagation();
+    removeTask(task.id);
+    toast.success("Tâche supprimée avec succès");
+  }}
               className="text-xs text-red-500 hover:underline"
             >
               Supprimer

--- a/src/components/TaskCard/TaskCard.tsx
+++ b/src/components/TaskCard/TaskCard.tsx
@@ -1,4 +1,5 @@
 import { useState } from "react";
+import { useDraggable } from "@dnd-kit/core";
 import { TaskModal } from "@/components/TaskModal";
 import { toast } from "sonner";
 import { useTaskStore } from "@/store/useTaskStore";
@@ -35,9 +36,28 @@ function getPriorityColor(priority?: Task["priority"]) {
 export default function TaskCard({ task }: TaskCardProps) {
   const [editOpen, setEditOpen] = useState(false);
   const { toggleTask, removeTask, updateTask } = useTaskStore();
+    const { attributes, listeners, setNodeRef, transform, isDragging } = useDraggable({
+    id: task.id,
+    data: {
+      task,
+    },
+  });
+
+    const style = transform
+    ? {
+        transform: `translate3d(${transform.x}px, ${transform.y}px, 0)`,
+      }
+    : undefined;
 
   return (
-    <>
+    <div
+    ref={setNodeRef}
+      {...attributes}
+      {...listeners}
+      style={style}
+      className={`transition-opacity ${
+        isDragging ? "opacity-50" : ""
+      }`}>
       <Card className="mb-2">
         <CardContent className="flex flex-col sm:flex-row justify-between items-start sm:items-center gap-3 p-4">
           <div className="flex items-center gap-3">
@@ -108,11 +128,11 @@ export default function TaskCard({ task }: TaskCardProps) {
         onOpenChange={setEditOpen}
         initialTask={task}
         onUpdate={(updatedTask) => {
-          updateTask(updatedTask);
+          updateTask(updatedTask.id, updatedTask);
           toast.success("Tâche modifiée avec succès");
           setEditOpen(false);
         }}
       />
-    </>
+    </div>
   );
 }

--- a/src/components/TaskColumn.tsx/TaskColumn.tsx
+++ b/src/components/TaskColumn.tsx/TaskColumn.tsx
@@ -1,4 +1,5 @@
-import type { Task } from "@/components/TaskCard/TaskCard";
+import type { Task } from "@/store/useTaskStore";
+import { useDroppable } from "@dnd-kit/core";
 import TaskCard from "@/components/TaskCard/TaskCard";
 
 type TaskColumnProps = {
@@ -8,7 +9,9 @@ type TaskColumnProps = {
 };
 
 export function TaskColumn({ title, status, tasks }: TaskColumnProps) {
-
+  const { isOver, setNodeRef } = useDroppable({
+    id: status,
+  });
 
   const bgColor = {
     todo: "bg-slate-50",
@@ -23,7 +26,9 @@ export function TaskColumn({ title, status, tasks }: TaskColumnProps) {
   }[status];
 
   return (
-    <div className={`rounded-lg p-4 shadow-sm ${bgColor} flex flex-col gap-2`}>
+    <div 
+    ref={setNodeRef}
+    className={`rounded-lg p-4 shadow-sm ${bgColor} flex flex-col gap-2 ${isOver ? "ring-2 ring-blue-500" : ""}`}>
       <h2 className={`text-md font-semibold mb-2 uppercase tracking-wide ${textColor}`}>
         {title}
       </h2>

--- a/src/store/useTaskStore.ts
+++ b/src/store/useTaskStore.ts
@@ -16,7 +16,7 @@ export interface Task {
 interface TaskStore {
   tasks: Task[];
   addTask: (task: Task) => void;
-  updateTask: (updatedTask: Task) => void;
+  updateTask: (id: string , partial: Partial<Task>) => void;
   removeTask: (id: string) => void;
   toggleTask: (id: string) => void;
   setTasks: (tasks: Task[]) => void;
@@ -31,10 +31,10 @@ export const useTaskStore = create<TaskStore>()(
       viewMode: "kanban",
       setViewMode: (mode) => set({ viewMode: mode }),
       addTask: (task) => set((state) => ({ tasks: [...state.tasks, task] })),
-      updateTask: (updatedTask: Task) =>
+      updateTask: (id, partial) =>
         set((state) => ({
           tasks: state.tasks.map((task) =>
-            task.id === updatedTask.id ? { ...task, ...updatedTask } : task
+            task.id === id ? { ...task, ...partial } : task
           ),
         })),
       removeTask: (id) =>

--- a/src/store/useTaskStore.ts
+++ b/src/store/useTaskStore.ts
@@ -11,12 +11,13 @@ export interface Task {
   status: TaskStatus;
   dueDate?: string;
   priority?: "low" | "medium" | "high";
+  order?: number; // For kanban board ordering
 }
 
 interface TaskStore {
   tasks: Task[];
   addTask: (task: Task) => void;
-  updateTask: (id: string , partial: Partial<Task>) => void;
+  updateTask: (id: string, partial: Partial<Task>) => void;
   removeTask: (id: string) => void;
   toggleTask: (id: string) => void;
   setTasks: (tasks: Task[]) => void;
@@ -30,7 +31,16 @@ export const useTaskStore = create<TaskStore>()(
       tasks: [],
       viewMode: "kanban",
       setViewMode: (mode) => set({ viewMode: mode }),
-      addTask: (task) => set((state) => ({ tasks: [...state.tasks, task] })),
+      addTask: (task) =>
+        set((state) => {
+          const maxOrder = Math.max(
+            0,
+            ...state.tasks
+              .filter((t) => t.status === task.status)
+              .map((t) => t.order ?? 0)
+          );
+          return { tasks: [...state.tasks, { ...task, order: maxOrder + 1 }] };
+        }),
       updateTask: (id, partial) =>
         set((state) => ({
           tasks: state.tasks.map((task) =>


### PR DESCRIPTION
This PR introduces drag-and-drop functionality to the Kanban and List views using @dnd-kit/core (v6.3.1). Key changes include:

- Wrapped KanbanBoard and ListView in isolated DndContext instances to prevent unwanted interference with other views (e.g., Calendar).
- Made each TaskCard draggable using `useDraggable`.
- Made TaskColumn and ListGroup components droppable using `useDroppable`, with visual drop indicators.
- Refactored the `updateTask` method in the Zustand store to accept partial updates.
- On drag end, the task’s status is automatically updated based on the destination column or group.

All interactions are responsive and visually enhanced to guide the user while dragging tasks.